### PR TITLE
Improved ScanMatcher to perform observable transformation

### DIFF
--- a/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/NameScanMatcher.java
+++ b/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/NameScanMatcher.java
@@ -3,8 +3,12 @@ package com.uber.rxcentralble.sample;
 import android.annotation.TargetApi;
 import android.os.Build;
 
+import com.jakewharton.rxrelay2.PublishRelay;
 import com.uber.rxcentralble.ScanData;
 import com.uber.rxcentralble.ScanMatcher;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableTransformer;
 
 public class NameScanMatcher implements ScanMatcher {
 
@@ -15,25 +19,29 @@ public class NameScanMatcher implements ScanMatcher {
   }
 
   @Override
-  public boolean match(ScanData scanData) {
-    String scanRecordName = "";
-    String deviceName = "";
-    String adDataName = "";
+  public ObservableTransformer<ScanData, ScanData> match() {
+    return scanDataStream ->
+            scanDataStream
+            .filter(scanData -> {
+              String scanRecordName = "";
+              String deviceName = "";
+              String adDataName = "";
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      scanRecordName = getScanRecordName(scanData);
-    }
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                scanRecordName = getScanRecordName(scanData);
+              }
 
-    if (scanData.getBluetoothDevice().getName() != null) {
-      deviceName = scanData.getBluetoothDevice().getName();
-    }
+              if (scanData.getBluetoothDevice().getName() != null) {
+                deviceName = scanData.getBluetoothDevice().getName();
+              }
 
-    if (scanData.getParsedAdvertisement() != null
-            && scanData.getParsedAdvertisement().getName() != null) {
-      adDataName = scanData.getParsedAdvertisement().getName();
-    }
+              if (scanData.getParsedAdvertisement() != null
+                      && scanData.getParsedAdvertisement().getName() != null) {
+                adDataName = scanData.getParsedAdvertisement().getName();
+              }
 
-    return scanRecordName.contentEquals(name) || deviceName.contentEquals(name) || adDataName.contentEquals(name);
+              return scanRecordName.contentEquals(name) || deviceName.contentEquals(name) || adDataName.contentEquals(name);
+            });
   }
 
   @Override
@@ -61,4 +69,6 @@ public class NameScanMatcher implements ScanMatcher {
       return "";
     }
   }
+
+
 }

--- a/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/NameScanMatcher.java
+++ b/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/NameScanMatcher.java
@@ -3,11 +3,9 @@ package com.uber.rxcentralble.sample;
 import android.annotation.TargetApi;
 import android.os.Build;
 
-import com.jakewharton.rxrelay2.PublishRelay;
 import com.uber.rxcentralble.ScanData;
 import com.uber.rxcentralble.ScanMatcher;
 
-import io.reactivex.Observable;
 import io.reactivex.ObservableTransformer;
 
 public class NameScanMatcher implements ScanMatcher {
@@ -40,7 +38,9 @@ public class NameScanMatcher implements ScanMatcher {
                 adDataName = scanData.getParsedAdvertisement().getName();
               }
 
-              return scanRecordName.contentEquals(name) || deviceName.contentEquals(name) || adDataName.contentEquals(name);
+              return scanRecordName.contentEquals(name)
+                      || deviceName.contentEquals(name)
+                      || adDataName.contentEquals(name);
             });
   }
 
@@ -69,6 +69,4 @@ public class NameScanMatcher implements ScanMatcher {
       return "";
     }
   }
-
-
 }

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/ScanMatcher.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/ScanMatcher.java
@@ -15,15 +15,13 @@
  */
 package com.uber.rxcentralble;
 
-/** Provides the capability to specify means to identify discovered peripheral matches. */
+import io.reactivex.ObservableTransformer;
+
+/** Provides the capability to specify logic to identify discovered peripheral matches. */
 public interface ScanMatcher {
 
   /**
-   * Determines if the ScanData for a discovered peripheral is a match against parameters and logic
-   * specified by this ScanMatcher.
-   *
-   * @param scanData the ScanData for a discovered peripheral.
-   * @return true if it's a match, else false.
+   * Transform a stream of discovered peripherals into the desired matches.
    */
-  boolean match(ScanData scanData);
+  ObservableTransformer<ScanData, ScanData> match();
 }

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/Scanner.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/Scanner.java
@@ -30,11 +30,9 @@ public interface Scanner {
    *   <dd>{@code connect} does not operate by default on a particular {@link Scheduler}.
    * </dl>
    *
-   * @param scanMatcher matcher used to match discovered peripherals.
-   * @return Observable stream of discovered peripheral ScanData that match the provided
-   *     ScanMatcher, or else an error. {@link ConnectionError} will occur in cases where you can
-   *     retry scanning
+   * @return Observable stream of discovered peripheral ScanDat or else an error.
+   * {@link ConnectionError} will occur in cases where you canretry scanning
    */
   @SchedulerSupport(SchedulerSupport.NONE)
-  Observable<ScanData> scan(ScanMatcher scanMatcher);
+  Observable<ScanData> scan();
 }

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
@@ -29,7 +29,6 @@ import com.uber.rxcentralble.ParsedAdvertisement;
 import com.uber.rxcentralble.ScanData;
 import com.uber.rxcentralble.ScanMatcher;
 import com.uber.rxcentralble.Scanner;
-import com.uber.rxcentralble.Optional;
 import com.uber.rxcentralble.core.scanners.JellyBeanScanner;
 import com.uber.rxcentralble.core.scanners.LollipopScanner;
 
@@ -124,6 +123,7 @@ public class CoreConnectionManager implements ConnectionManager {
   private ObservableTransformer<Boolean, ScanData> scan(Scanner scanner) {
     return bluetoothEnabled ->
             bluetoothEnabled
+                .doOnNext(connectableGattIO -> stateRelay.accept(State.SCANNING))
                 .switchMap(enabled -> scanner.scan())
                 .compose(scanMatcher != null ? scanMatcher.match() : scanData -> scanData)
                 .firstOrError()

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/JellyBeanScanner.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/JellyBeanScanner.java
@@ -39,7 +39,6 @@ public class JellyBeanScanner implements Scanner {
   private final BluetoothAdapter.LeScanCallback leScanCallback;
 
   @Nullable private PublishSubject<ScanData> scanDataSubject;
-  @Nullable private ScanMatcher scanMatcher;
 
   public JellyBeanScanner(ParsedAdvertisement.Factory parsedAdDataFactory) {
     this.parsedAdDataFactory = parsedAdDataFactory;
@@ -47,12 +46,11 @@ public class JellyBeanScanner implements Scanner {
   }
 
   @Override
-  public Observable<ScanData> scan(ScanMatcher scanMatcher) {
+  public Observable<ScanData> scan() {
     if (scanDataSubject != null) {
       return Observable.error(new ConnectionError(SCAN_IN_PROGRESS));
     }
 
-    this.scanMatcher = scanMatcher;
     this.scanDataSubject = PublishSubject.create();
 
     return scanDataSubject
@@ -89,11 +87,9 @@ public class JellyBeanScanner implements Scanner {
   /** Implementation of Android LeScanCallback. */
   private BluetoothAdapter.LeScanCallback getScanCallback() {
     return (bluetoothDevice, rssi, eirData) -> {
-      if (scanMatcher != null && scanDataSubject != null) {
+      if (scanDataSubject != null) {
         ScanData scanData = new JellyBeanScanData(bluetoothDevice, rssi, parsedAdDataFactory.produce(eirData));
-        if (scanMatcher.match(scanData)) {
-          scanDataSubject.onNext(scanData);
-        }
+        scanDataSubject.onNext(scanData);
       }
     };
   }

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/JellyBeanScanner.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/JellyBeanScanner.java
@@ -22,7 +22,6 @@ import android.support.annotation.Nullable;
 import com.uber.rxcentralble.ParsedAdvertisement;
 import com.uber.rxcentralble.ScanData;
 import com.uber.rxcentralble.ConnectionError;
-import com.uber.rxcentralble.ScanMatcher;
 import com.uber.rxcentralble.Scanner;
 
 import io.reactivex.Observable;

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
@@ -48,7 +48,6 @@ public class LollipopScanner implements Scanner {
   private final ScanCallback scanCallback;
 
   @Nullable private PublishSubject<ScanData> scanDataSubject;
-  @Nullable private ScanMatcher scanMatcher;
 
   public LollipopScanner(ParsedAdvertisement.Factory parsedAdDataFactory) {
     this.parsedAdDataFactory = parsedAdDataFactory;
@@ -56,12 +55,11 @@ public class LollipopScanner implements Scanner {
   }
 
   @Override
-  public Observable<ScanData> scan(ScanMatcher scanMatcher) {
+  public Observable<ScanData> scan() {
     if (scanDataSubject != null) {
       return Observable.error(new ConnectionError(SCAN_IN_PROGRESS));
     }
 
-    this.scanMatcher = scanMatcher;
     this.scanDataSubject = PublishSubject.create();
 
     return scanDataSubject
@@ -137,9 +135,7 @@ public class LollipopScanner implements Scanner {
         }
 
         ScanData scanData = new LollipopScanData(scanResult, parsedAdvertisement);
-        if (scanDataSubject != null && scanMatcher != null && scanMatcher.match(scanData)) {
-          scanDataSubject.onNext(scanData);
-        }
+        scanDataSubject.onNext(scanData);
       }
     };
   }

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
@@ -26,7 +26,6 @@ import android.bluetooth.le.ScanSettings;
 import com.uber.rxcentralble.ParsedAdvertisement;
 import com.uber.rxcentralble.ScanData;
 import com.uber.rxcentralble.ConnectionError;
-import com.uber.rxcentralble.ScanMatcher;
 import com.uber.rxcentralble.Scanner;
 
 import java.util.ArrayList;

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/CoreConnectionManagerTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/CoreConnectionManagerTest.java
@@ -35,6 +35,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.concurrent.TimeUnit;
 
+import io.reactivex.ObservableTransformer;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.TestScheduler;
@@ -78,7 +79,7 @@ public class CoreConnectionManagerTest  {
 
     RxJavaPlugins.setComputationSchedulerHandler(schedulerCallable -> testScheduler);
 
-    when(scanner.scan(any())).thenReturn(scanDataPublishSubject.hide());
+    when(scanner.scan()).thenReturn(scanDataPublishSubject.hide());
     when(bluetoothDetector.enabled()).thenReturn(bluetoothEnabledRelay.hide());
     when(gattIOFactory.produce(any(), any())).thenReturn(gattIO);
     when(gattIO.connect()).thenReturn(connectableStatePublishSubject.hide());
@@ -214,8 +215,8 @@ public class CoreConnectionManagerTest  {
     scanMatcher =
         new ScanMatcher() {
           @Override
-          public boolean match(ScanData scanData) {
-            return true;
+          public ObservableTransformer<ScanData, ScanData> match() {
+            return scanData -> scanData;
           }
 
           @Override

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/JellyBeanScannerTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/JellyBeanScannerTest.java
@@ -52,7 +52,6 @@ public class JellyBeanScannerTest {
 
   @Mock ParsedAdvertisement.Factory adDataFactory;
   @Mock ParsedAdvertisement parsedAdvertisement;
-  @Mock ScanMatcher scanMatcher;
   @Mock BluetoothAdapter bluetoothAdapter;
   @Mock BluetoothDevice bluetoothDevice;
 
@@ -67,7 +66,6 @@ public class JellyBeanScannerTest {
 
     when(bluetoothAdapter.startLeScan(any())).thenReturn(true);
     when(adDataFactory.produce(any())).thenReturn(parsedAdvertisement);
-    when(scanMatcher.match(any())).thenReturn(true);
 
     scanner = new JellyBeanScanner(adDataFactory);
   }
@@ -76,7 +74,7 @@ public class JellyBeanScannerTest {
   public void scan_failed_bluetoothUnsupported() {
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(null);
 
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanDataTestObserver = scanner.scan().test();
 
     scanDataTestObserver.assertError(
         throwable -> {
@@ -90,7 +88,7 @@ public class JellyBeanScannerTest {
     when(bluetoothAdapter.isEnabled()).thenReturn(false);
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(bluetoothAdapter);
 
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanDataTestObserver = scanner.scan().test();
 
     scanDataTestObserver.assertError(
         throwable -> {
@@ -104,8 +102,8 @@ public class JellyBeanScannerTest {
     when(bluetoothAdapter.isEnabled()).thenReturn(true);
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(bluetoothAdapter);
 
-    scanner.scan(scanMatcher).test();
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanner.scan().test();
+    scanDataTestObserver = scanner.scan().test();
 
     scanDataTestObserver.assertError(
         throwable -> {
@@ -119,7 +117,7 @@ public class JellyBeanScannerTest {
     when(bluetoothAdapter.isEnabled()).thenReturn(true);
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(bluetoothAdapter);
 
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanDataTestObserver = scanner.scan().test();
 
     ArgumentCaptor<BluetoothAdapter.LeScanCallback> argument =
         ArgumentCaptor.forClass(BluetoothAdapter.LeScanCallback.class);

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/JellyBeanScannerTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/JellyBeanScannerTest.java
@@ -21,7 +21,6 @@ import android.bluetooth.BluetoothDevice;
 import com.uber.rxcentralble.ConnectionError;
 import com.uber.rxcentralble.ParsedAdvertisement;
 import com.uber.rxcentralble.ScanData;
-import com.uber.rxcentralble.ScanMatcher;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/LollipopScannerTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/LollipopScannerTest.java
@@ -25,7 +25,6 @@ import android.bluetooth.le.ScanResult;
 import com.uber.rxcentralble.ConnectionError;
 import com.uber.rxcentralble.ParsedAdvertisement;
 import com.uber.rxcentralble.ScanData;
-import com.uber.rxcentralble.ScanMatcher;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/LollipopScannerTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/scanners/LollipopScannerTest.java
@@ -57,7 +57,6 @@ public class LollipopScannerTest {
   @Mock ParsedAdvertisement.Factory adDataFactory;
   @Mock ParsedAdvertisement parsedAdvertisement;
 
-  @Mock ScanMatcher scanMatcher;
   @Mock BluetoothAdapter bluetoothAdapter;
   @Mock BluetoothLeScanner bluetoothLeScanner;
   @Mock BluetoothDevice bluetoothDevice;
@@ -75,7 +74,6 @@ public class LollipopScannerTest {
 
     when(bluetoothAdapter.getBluetoothLeScanner()).thenReturn(bluetoothLeScanner);
     when(adDataFactory.produce(any())).thenReturn(parsedAdvertisement);
-    when(scanMatcher.match(any())).thenReturn(true);
     when(scanResult.getDevice()).thenReturn(bluetoothDevice);
     when(scanResult.getScanRecord()).thenReturn(scanRecord);
     when(scanRecord.getBytes()).thenReturn(new byte[] {0x00});
@@ -88,7 +86,7 @@ public class LollipopScannerTest {
   public void scan_failed_bluetoothUnsupported() {
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(null);
 
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanDataTestObserver = scanner.scan().test();
 
     scanDataTestObserver.assertError(
         throwable -> {
@@ -102,7 +100,7 @@ public class LollipopScannerTest {
     when(bluetoothAdapter.isEnabled()).thenReturn(false);
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(bluetoothAdapter);
 
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanDataTestObserver = scanner.scan().test();
 
     scanDataTestObserver.assertError(
         throwable -> {
@@ -116,8 +114,8 @@ public class LollipopScannerTest {
     when(bluetoothAdapter.isEnabled()).thenReturn(true);
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(bluetoothAdapter);
 
-    scanner.scan(scanMatcher).test();
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanner.scan().test();
+    scanDataTestObserver = scanner.scan().test();
 
     scanDataTestObserver.assertError(
         throwable -> {
@@ -131,7 +129,7 @@ public class LollipopScannerTest {
     when(bluetoothAdapter.isEnabled()).thenReturn(true);
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(bluetoothAdapter);
 
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanDataTestObserver = scanner.scan().test();
 
     ArgumentCaptor<ScanCallback> argument = ArgumentCaptor.forClass(ScanCallback.class);
     verify(bluetoothLeScanner).startScan(any(), any(), argument.capture());
@@ -150,7 +148,7 @@ public class LollipopScannerTest {
     when(bluetoothAdapter.isEnabled()).thenReturn(true);
     when(BluetoothAdapter.getDefaultAdapter()).thenReturn(bluetoothAdapter);
 
-    scanDataTestObserver = scanner.scan(scanMatcher).test();
+    scanDataTestObserver = scanner.scan().test();
 
     ArgumentCaptor<ScanCallback> argument = ArgumentCaptor.forClass(ScanCallback.class);
     verify(bluetoothLeScanner).startScan(any(), any(), argument.capture());


### PR DESCRIPTION
The ScanMatcher interface was limited to performing synchronous comparisons.  Using an ObservableTransformer to perform matching provides greater flexibility and allows for performing asynchronous comparisons.