### PR TITLE
Scanning Fixes + Write Chunking Fixes

### DIFF
--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
@@ -93,15 +93,15 @@ public class CoreConnectionManager implements ConnectionManager {
       ScanMatcher scanMatcher, int scanTimeoutMs, int connectionTimeoutMs) {
     if (this.scanMatcher != null && !this.scanMatcher.equals(scanMatcher)) {
       return Observable.error(new ConnectionError(CONNECTION_IN_PROGRESS));
-    }
-    else if (sharedGattIOObservable != null){
+    } else if (sharedGattIOObservable != null) {
       return sharedGattIOObservable;
     }
 
     this.scanTimeoutMs = scanTimeoutMs;
     this.connectionTimeoutMs = connectionTimeoutMs;
     this.scanMatcher = scanMatcher;
-    this.sharedGattIOObservable = createdSharedObservable(context, bluetoothDetector, scanner, scanMatcher, gattIOFactory);
+    this.sharedGattIOObservable = createdSharedObservable(context, bluetoothDetector, scanner,
+            scanMatcher, gattIOFactory);
 
     return sharedGattIOObservable;
   }

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
@@ -45,11 +45,16 @@ import static com.uber.rxcentralble.ConnectionError.Code.SCAN_TIMEOUT;
 /** Core implementation of ConnectionManager. */
 public class CoreConnectionManager implements ConnectionManager {
 
-  private final Observable<GattIO> sharedGattIOObservable;
   private final BehaviorRelay<State> stateRelay = BehaviorRelay.createDefault(State.DISCONNECTED);
+  private final Context context;
+  private final BluetoothDetector bluetoothDetector;
+  private final Scanner scanner;
+  private final GattIO.Factory gattIOFactory;
 
   @Nullable
   private ScanMatcher scanMatcher;
+  @Nullable
+  private Observable<GattIO> sharedGattIOObservable;
 
   private int scanTimeoutMs = DEFAULT_SCAN_TIMEOUT;
   private int connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT;
@@ -59,15 +64,16 @@ public class CoreConnectionManager implements ConnectionManager {
           BluetoothDetector bluetoothDetector,
           GattIO.Factory gattIOFactory) {
 
-    Scanner scanner;
     ParsedAdvertisement.Factory factory = new CoreParsedAdvertisement.Factory();
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      scanner = new JellyBeanScanner(factory);
+      this.scanner = new JellyBeanScanner(factory);
     } else {
-      scanner = new LollipopScanner(factory);
+      this.scanner = new LollipopScanner(factory);
     }
 
-    sharedGattIOObservable = createdSharedObservable(context, bluetoothDetector, scanner, gattIOFactory);
+    this.context = context;
+    this.bluetoothDetector = bluetoothDetector;
+    this.gattIOFactory = gattIOFactory;
   }
 
   public CoreConnectionManager(
@@ -76,7 +82,10 @@ public class CoreConnectionManager implements ConnectionManager {
       Scanner scanner,
       GattIO.Factory gattIOFactory) {
 
-    sharedGattIOObservable = createdSharedObservable(context, bluetoothDetector, scanner, gattIOFactory);
+    this.context = context;
+    this.bluetoothDetector = bluetoothDetector;
+    this.gattIOFactory = gattIOFactory;
+    this.scanner = scanner;
   }
 
   @Override
@@ -85,10 +94,14 @@ public class CoreConnectionManager implements ConnectionManager {
     if (this.scanMatcher != null && !this.scanMatcher.equals(scanMatcher)) {
       return Observable.error(new ConnectionError(CONNECTION_IN_PROGRESS));
     }
+    else if (sharedGattIOObservable != null){
+      return sharedGattIOObservable;
+    }
 
     this.scanTimeoutMs = scanTimeoutMs;
     this.connectionTimeoutMs = connectionTimeoutMs;
     this.scanMatcher = scanMatcher;
+    this.sharedGattIOObservable = createdSharedObservable(context, bluetoothDetector, scanner, scanMatcher, gattIOFactory);
 
     return sharedGattIOObservable;
   }
@@ -101,31 +114,30 @@ public class CoreConnectionManager implements ConnectionManager {
   private Observable<GattIO> createdSharedObservable(Context context,
                     BluetoothDetector bluetoothDetector,
                     Scanner scanner,
+                    ScanMatcher scanMatcher,
                     GattIO.Factory gattIOFactory) {
 
     return bluetoothDetector
                 .enabled()
                 .distinctUntilChanged()
                 .filter(enabled -> enabled)
-                .compose(scan(scanner))
+                .compose(scan(scanner, scanMatcher))
                 .compose(connectGatt(gattIOFactory, context))
                 .doOnNext(connectableGattIO -> stateRelay.accept(State.CONNECTED))
-                .doOnDispose(() -> {
-                  scanMatcher = null;
-                  stateRelay.accept(State.DISCONNECTED);
-                })
+                .doOnDispose(() -> stateRelay.accept(State.DISCONNECTED))
                 .doOnError(error -> stateRelay.accept(State.DISCONNECTED_WITH_ERROR))
+                .doFinally(() -> this.scanMatcher = null)
                 .map(connectableGattIO -> connectableGattIO)
                 .replay(1)
                 .refCount();
   }
 
-  private ObservableTransformer<Boolean, ScanData> scan(Scanner scanner) {
+  private ObservableTransformer<Boolean, ScanData> scan(Scanner scanner, ScanMatcher scanMatcher) {
     return bluetoothEnabled ->
             bluetoothEnabled
                 .doOnNext(connectableGattIO -> stateRelay.accept(State.SCANNING))
                 .switchMap(enabled -> scanner.scan())
-                .compose(scanMatcher != null ? scanMatcher.match() : scanData -> scanData)
+                .compose(scanMatcher.match())
                 .firstOrError()
                 .timeout(
                     scanTimeoutMs,

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/operations/AbstractWrite.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/operations/AbstractWrite.java
@@ -96,10 +96,7 @@ public abstract class AbstractWrite<T> implements GattOperation<T> {
                                 bytesSentRelay.getValue() + gattChunk.second.length))
                     .andThen(Single.just(gattChunk.first)))
         .lastOrError()
-        .doOnSubscribe(
-            d -> {
-              bytesSentRelay.accept(0);
-            });
+        .doOnSubscribe(d -> bytesSentRelay.accept(0));
   }
 
   protected abstract SingleTransformer<GattIO, T> postWrite();
@@ -121,14 +118,15 @@ public abstract class AbstractWrite<T> implements GattOperation<T> {
     byte[] chunk = new byte[maxWriteLength];
     ByteBuffer byteBuffer = ByteBuffer.wrap(data);
 
-    while (maxWriteLength < byteBuffer.remaining()) {
+    while (maxWriteLength <= byteBuffer.remaining()) {
       byteBuffer.get(chunk, 0, chunk.length);
       chunks.onNext(new Pair<>(gattIO, chunk));
     }
 
     if (byteBuffer.hasRemaining()) {
-      byteBuffer.get(chunk, 0, byteBuffer.remaining());
-      chunks.onNext(new Pair<>(gattIO, chunk));
+      byte[] remaining = new byte[byteBuffer.remaining()];
+      byteBuffer.get(remaining, 0, byteBuffer.remaining());
+      chunks.onNext(new Pair<>(gattIO, remaining));
     }
 
     chunks.onComplete();

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/operations/AbstractWrite.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/operations/AbstractWrite.java
@@ -122,11 +122,13 @@ public abstract class AbstractWrite<T> implements GattOperation<T> {
     ByteBuffer byteBuffer = ByteBuffer.wrap(data);
 
     while (maxWriteLength < byteBuffer.remaining()) {
-      chunks.onNext(new Pair<>(gattIO, byteBuffer.get(chunk, 0, chunk.length).array()));
+      byteBuffer.get(chunk, 0, chunk.length);
+      chunks.onNext(new Pair<>(gattIO, chunk));
     }
 
     if (byteBuffer.hasRemaining()) {
-      chunks.onNext(new Pair<>(gattIO, byteBuffer.get(chunk, 0, byteBuffer.remaining()).array()));
+      byteBuffer.get(chunk, 0, byteBuffer.remaining());
+      chunks.onNext(new Pair<>(gattIO, chunk));
     }
 
     chunks.onComplete();

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import io.reactivex.Observable;
 import io.reactivex.subjects.PublishSubject;
@@ -98,6 +99,7 @@ public class LollipopScanner implements Scanner {
     if (adapter != null) {
       BluetoothLeScanner bleScanner = adapter.getBluetoothLeScanner();
       if (bleScanner != null) {
+        Log.d("BLAR", "STOP SCAN");
         bleScanner.stopScan(scanCallback);
       }
     }
@@ -128,13 +130,15 @@ public class LollipopScanner implements Scanner {
       }
 
       private void handleScanData(ScanResult scanResult) {
-        ParsedAdvertisement parsedAdvertisement = null;
-        if (scanResult.getScanRecord() != null) {
-          parsedAdvertisement = parsedAdDataFactory.produce(scanResult.getScanRecord().getBytes());
-        }
+        if (scanDataSubject != null) {
+          ParsedAdvertisement parsedAdvertisement = null;
+          if (scanResult.getScanRecord() != null) {
+            parsedAdvertisement = parsedAdDataFactory.produce(scanResult.getScanRecord().getBytes());
+          }
 
-        ScanData scanData = new LollipopScanData(scanResult, parsedAdvertisement);
-        scanDataSubject.onNext(scanData);
+          ScanData scanData = new LollipopScanData(scanResult, parsedAdvertisement);
+          scanDataSubject.onNext(scanData);
+        }
       }
     };
   }

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/operations/WriteTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/operations/WriteTest.java
@@ -35,7 +35,6 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.CompletableSubject;
 
-import static com.uber.rxcentralble.GattIO.DEFAULT_MTU;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/operations/WriteTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/operations/WriteTest.java
@@ -22,6 +22,7 @@ import com.uber.rxcentralble.Irrelevant;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -35,14 +36,16 @@ import io.reactivex.schedulers.TestScheduler;
 import io.reactivex.subjects.CompletableSubject;
 
 import static com.uber.rxcentralble.GattIO.DEFAULT_MTU;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
-public class WriteTest  {
+public class WriteTest {
 
-  @Mock GattIO gattIO;
+  @Mock
+  GattIO gattIO;
 
   private final TestScheduler testScheduler = new TestScheduler();
   private final UUID svcUuid = UUID.randomUUID();
@@ -60,15 +63,6 @@ public class WriteTest  {
     RxJavaPlugins.setComputationSchedulerHandler(schedulerCallable -> testScheduler);
 
     when(gattIO.write(any(), any(), any())).thenReturn(writeCompletable);
-    when(gattIO.getMaxWriteLength()).thenReturn(DEFAULT_MTU);
-
-    data = new byte[128];
-    for (int i = 0; i < 128; i++) {
-      data[i] = (byte) i;
-    }
-
-    write = new Write(svcUuid, chrUuid, data, 5000);
-    writeResultTestObserver = write.result().test();
   }
 
   @After
@@ -78,6 +72,8 @@ public class WriteTest  {
 
   @Test
   public void write_timeout() {
+    prepareWrite(20, 128);
+    writeResultTestObserver = write.result().test();
     write.execute(gattIO);
 
     testScheduler.advanceTimeBy(5000 + 1000, TimeUnit.MILLISECONDS);
@@ -87,6 +83,8 @@ public class WriteTest  {
 
   @Test
   public void write_error() {
+    prepareWrite(20, 128);
+    writeResultTestObserver = write.result().test();
     write.execute(gattIO);
 
     writeCompletable.onError(new GattError(GattError.Code.MISSING_CHARACTERISTIC));
@@ -95,24 +93,84 @@ public class WriteTest  {
   }
 
   @Test
-  public void write_success() {
-    write.execute(gattIO);
+  public void write_execute_withResult() {
+    prepareWrite(20, 128);
+    writeResultTestObserver = write.executeWithResult(gattIO).test();
 
     writeCompletable.onComplete();
 
-    verify(gattIO, times((128 / DEFAULT_MTU) + 1)).write(any(), any(), any());
+    verifyChunks(20, 128);
 
     writeResultTestObserver.assertComplete();
   }
 
   @Test
-  public void write_execute_withResult() {
-    writeResultTestObserver = write.executeWithResult(gattIO).test();
+  public void write_success_mtuLessLength() {
+    prepareWrite(20, 128);
+    writeResultTestObserver = write.result().test();
+
+    write.execute(gattIO);
 
     writeCompletable.onComplete();
 
-    verify(gattIO, times((128 / DEFAULT_MTU) + 1)).write(any(), any(), any());
+    verifyChunks(20, 128);
 
     writeResultTestObserver.assertComplete();
+  }
+
+  @Test
+  public void write_success_mtuEqualLength() {
+    prepareWrite(128, 128);
+    writeResultTestObserver = write.result().test();
+
+    write.execute(gattIO);
+
+    writeCompletable.onComplete();
+
+    verifyChunks(128, 128);
+
+    writeResultTestObserver.assertComplete();
+  }
+
+  @Test
+  public void write_success_mtuGreaterLength() {
+    prepareWrite(256, 47);
+    writeResultTestObserver = write.result().test();
+
+    write.execute(gattIO);
+
+    writeCompletable.onComplete();
+
+    verifyChunks(256, 47);
+
+    writeResultTestObserver.assertComplete();
+  }
+
+  private void prepareWrite(int mtu, int length) {
+    when(gattIO.getMaxWriteLength()).thenReturn(mtu);
+
+    data = new byte[length];
+    for (int i = 0; i < length; i++) {
+      data[i] = (byte) i;
+    }
+
+    write = new Write(svcUuid, chrUuid, data, 5000);
+  }
+
+  private void verifyChunks(int mtu, int length) {
+    ArgumentCaptor<byte[]> chunkCaptor = ArgumentCaptor.forClass(byte[].class);
+    int numInvocations = length / mtu;
+    if (length % mtu != 0) {
+      numInvocations++;
+    }
+    verify(gattIO, times(numInvocations)).write(any(), any(), chunkCaptor.capture());
+
+    for (int i = 0; i < length / mtu; i++) {
+      assertEquals(mtu, chunkCaptor.getAllValues().get(i).length);
+    }
+
+    if (length % mtu != 0) {
+      assertEquals(length % mtu, chunkCaptor.getAllValues().get(length / mtu).length);
+    }
   }
 }


### PR DESCRIPTION
This PR includes two changes:

- Scanning fixes to prevent NRE after scanning stops but tailing scan results are still received.
- Resolve bug where CoreConnectionManager reports connection in progress after an error.
- Resolve issues with Chunking in AbstractWrite.
- Add tests for AbstractWrite fixes.