### PR TITLE
Resolve issues with overextended final byte array in chunking

### DIFF
--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/operations/AbstractWrite.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/operations/AbstractWrite.java
@@ -114,11 +114,10 @@ public abstract class AbstractWrite<T> implements GattOperation<T> {
       GattIO gattIO, byte[] data, int maxWriteLength) {
 
     ReplaySubject<Pair<GattIO, byte[]>> chunks = ReplaySubject.create();
-
-    byte[] chunk = new byte[maxWriteLength];
     ByteBuffer byteBuffer = ByteBuffer.wrap(data);
 
     while (maxWriteLength <= byteBuffer.remaining()) {
+      byte[] chunk = new byte[maxWriteLength];
       byteBuffer.get(chunk, 0, chunk.length);
       chunks.onNext(new Pair<>(gattIO, chunk));
     }

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/operations/WriteTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/operations/WriteTest.java
@@ -26,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -165,11 +166,19 @@ public class WriteTest {
     verify(gattIO, times(numInvocations)).write(any(), any(), chunkCaptor.capture());
 
     for (int i = 0; i < length / mtu; i++) {
-      assertEquals(mtu, chunkCaptor.getAllValues().get(i).length);
+      byte[] chunk = chunkCaptor.getAllValues().get(i);
+      assertEquals(mtu, chunk.length);
+
+      byte[] original = Arrays.copyOfRange(data, i * mtu, i * mtu + mtu);
+      assertEquals(Arrays.hashCode(original), Arrays.hashCode(chunk));
     }
 
     if (length % mtu != 0) {
-      assertEquals(length % mtu, chunkCaptor.getAllValues().get(length / mtu).length);
+      byte[] chunk = chunkCaptor.getAllValues().get(length / mtu);
+      assertEquals(length % mtu, chunk.length);
+
+      byte[] original = Arrays.copyOfRange(data, (length / mtu) * mtu, ((length / mtu) * mtu) + (length % mtu));
+      assertEquals(Arrays.hashCode(original), Arrays.hashCode(chunk));
     }
   }
 }


### PR DESCRIPTION
The final chunk in a write is MTU-size in length instead of matching the exact length of chunk, resulting in a series of 0-value tailing bytes.  This was a regression in 1.0.3.