### PR TITLE
Miscellaneous workarounds for scanning on Android 7 and 8.1

### DIFF
--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/ConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/ConnectionManager.java
@@ -61,12 +61,14 @@ public interface ConnectionManager {
    *     minutes due to scan throttling in Android 7+
    * @param connectionTimeoutMs connection timeout in milliseconds. This is defined by the period
    *     between matching a peripheral for connection and establishing a connection. If a timeout
-   *     occurs, a {@link ConnectionError} with CONNECT_TIMEOUT code.
+   *     occurs, a {@link ConnectionError} with CONNECT_TIMEOUT code.  Must be positive.
    * @return Observable stream of connected GattIO. In event of an error, expect {@link
    *     ConnectionError} for errors that may be retried for a new connection attempt.
    */
   @SchedulerSupport(SchedulerSupport.NONE)
-  Observable<GattIO> connect(ScanMatcher scanMatcher, @IntRange(from=0,to=1740000) int scanTimeoutMs, int connectionTimeoutMs);
+  Observable<GattIO> connect(ScanMatcher scanMatcher,
+                             @IntRange(from = 0, to = 1740000) int scanTimeoutMs,
+                             @IntRange(from = 0) int connectionTimeoutMs);
 
   /**
    * Observe the internal state of the {@link ConnectionManager}.

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/ConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/ConnectionManager.java
@@ -15,6 +15,8 @@
  */
 package com.uber.rxcentralble;
 
+import android.support.annotation.IntRange;
+
 import io.reactivex.Observable;
 import io.reactivex.Scheduler;
 import io.reactivex.annotations.SchedulerSupport;
@@ -55,7 +57,8 @@ public interface ConnectionManager {
    * @param scanMatcher dictates the logic used to match a peripheral for connection. The {@link
    *     ConnectionManager} will connect to the first discovered peripheral that is a match.
    * @param scanTimeoutMs scan timeout in milliseconds. If a timeout occurs, a {@link
-   *     ConnectionError} will be thrown with SCAN_TIMEOUT code.
+   *     ConnectionError} will be thrown with SCAN_TIMEOUT code.  Maximum timeout should be 29
+   *     minutes due to scan throttling in Android 7+
    * @param connectionTimeoutMs connection timeout in milliseconds. This is defined by the period
    *     between matching a peripheral for connection and establishing a connection. If a timeout
    *     occurs, a {@link ConnectionError} with CONNECT_TIMEOUT code.
@@ -63,7 +66,7 @@ public interface ConnectionManager {
    *     ConnectionError} for errors that may be retried for a new connection attempt.
    */
   @SchedulerSupport(SchedulerSupport.NONE)
-  Observable<GattIO> connect(ScanMatcher scanMatcher, int scanTimeoutMs, int connectionTimeoutMs);
+  Observable<GattIO> connect(ScanMatcher scanMatcher, @IntRange(from=0,to=1740000) int scanTimeoutMs, int connectionTimeoutMs);
 
   /**
    * Observe the internal state of the {@link ConnectionManager}.

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
@@ -17,6 +17,7 @@ package com.uber.rxcentralble.core;
 
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.IntRange;
 import android.support.annotation.Nullable;
 import android.support.v4.util.Pair;
 
@@ -90,7 +91,7 @@ public class CoreConnectionManager implements ConnectionManager {
 
   @Override
   public Observable<GattIO> connect(
-      ScanMatcher scanMatcher, int scanTimeoutMs, int connectionTimeoutMs) {
+          ScanMatcher scanMatcher, int scanTimeoutMs, int connectionTimeoutMs) {
     if (this.scanMatcher != null && !this.scanMatcher.equals(scanMatcher)) {
       return Observable.error(new ConnectionError(CONNECTION_IN_PROGRESS));
     } else if (sharedGattIOObservable != null) {

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
@@ -17,7 +17,6 @@ package com.uber.rxcentralble.core;
 
 import android.content.Context;
 import android.os.Build;
-import android.support.annotation.IntRange;
 import android.support.annotation.Nullable;
 import android.support.v4.util.Pair;
 

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/scanners/LollipopScanner.java
@@ -77,8 +77,12 @@ public class LollipopScanner implements Scanner {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
     if (adapter != null && adapter.isEnabled()) {
       // Setting service uuid scan filter failing on Galaxy S6 on Android 7.
-      // Manually filter on scan operation.
+      // Other devices and versions of Android have additional issues with Scan Filters.
+      // Manually filter on scan operation.  Add a dummy filter to avoid Android 8.1+ enforcement
+      // of filters during background scanning.
       List<ScanFilter> filters = new ArrayList<>();
+      ScanFilter.Builder scanFilterBuilder = new ScanFilter.Builder();
+      filters.add(scanFilterBuilder.build());
 
       ScanSettings.Builder settingsBuilder = new ScanSettings.Builder();
       settingsBuilder.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY);


### PR DESCRIPTION
There are known issues with scanning on Android 7 and 8.1 as detailed [here](https://github.com/AltBeacon/android-beacon-library/issues/642#issuecomment-364165903).

These changes mitigate issues with scanning for 30+ minutes and background scanning without a scan filter.