### PR TITLE
Adjusted MaxWriteLength to reflect MTU minus 3 byte overhead

### DIFF
--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/GattIO.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/GattIO.java
@@ -26,7 +26,10 @@ public interface GattIO {
   UUID CCCD_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
 
   /** Default MTU for Bluetooth 4.0. */
-  int DEFAULT_MTU = 20;
+  int DEFAULT_MTU = 23;
+
+  /** Overhead for transmissions is 3 bytes. */
+  int MTU_OVERHEAD = 3;
 
   /**
    * Connect to the underlying peripheral.
@@ -203,9 +206,9 @@ public interface GattIO {
   Single<Integer> readRssi();
 
   /**
-   * Synchronously return the current MTU.
+   * Synchronously return the maximum length of a write operation.
    *
-   * @return the maximum length of a write operation i.e. the MTU.
+   * @return the maximum length of a write operation i.e. the MTU - MTU_OVERHEAD.
    */
   int getMaxWriteLength();
 

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreGattIO.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreGattIO.java
@@ -79,7 +79,7 @@ public class CoreGattIO implements GattIO {
   @Nullable private SingleSubject<Integer> requestMtuSubject;
   @Nullable private SingleSubject<Integer> readRssiSubject;
 
-  private int maxWriteLength = DEFAULT_MTU;
+  private int mtu = DEFAULT_MTU;
 
   public CoreGattIO(BluetoothDevice device, Context context) {
     this.context = context;
@@ -193,7 +193,7 @@ public class CoreGattIO implements GattIO {
 
   @Override
   public int getMaxWriteLength() {
-    return maxWriteLength;
+    return mtu - MTU_OVERHEAD;
   }
 
   @Override
@@ -636,7 +636,7 @@ public class CoreGattIO implements GattIO {
         }
 
         if (status == 0) {
-          maxWriteLength = mtu;
+          CoreGattIO.this.mtu = mtu;
         }
 
         operationResult(requestMtuSubject, mtu, status, REQUEST_MTU_FAILED);

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/CoreGattIOTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/CoreGattIOTest.java
@@ -62,6 +62,7 @@ import static com.uber.rxcentralble.GattError.Code.WRITE_DESCRIPTOR_FAILED;
 import static com.uber.rxcentralble.GattError.ERROR_STATUS_CALL_FAILED;
 import static com.uber.rxcentralble.GattIO.ConnectableState.CONNECTED;
 import static com.uber.rxcentralble.GattIO.ConnectableState.CONNECTING;
+import static com.uber.rxcentralble.GattIO.MTU_OVERHEAD;
 import static com.uber.rxcentralble.core.CoreGattIO.CCCD_UUID;
 import static com.uber.rxcentralble.core.CoreGattIO.DEFAULT_MTU;
 import static org.junit.Assert.assertEquals;
@@ -766,7 +767,7 @@ public class CoreGattIOTest {
               && error.getErrorStatus() == 99;
         });
 
-    assertEquals(coreGattIO.getMaxWriteLength(), DEFAULT_MTU);
+    assertEquals(coreGattIO.getMaxWriteLength(), DEFAULT_MTU - MTU_OVERHEAD);
   }
 
   @Test
@@ -781,7 +782,7 @@ public class CoreGattIOTest {
 
     setMtuTestObserver.assertValue(100);
 
-    assertEquals(coreGattIO.getMaxWriteLength(), 100);
+    assertEquals(coreGattIO.getMaxWriteLength(), 100 - MTU_OVERHEAD);
   }
 
   @Test


### PR DESCRIPTION
MaxWriteLength was incorrectly reflecting raw MTU value.  In reality, write length is MTU - 3 bytes of overhead.  

Changes made to GattIO to reflect this reality.
