### PR TITLE
Improved chunking logic for long writes to eliminate byte array dupli…

### DIFF
--- a/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/MainActivity.java
+++ b/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/MainActivity.java
@@ -9,10 +9,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import com.uber.rxcentralble.ConnectionError;
 import com.uber.rxcentralble.ConnectionManager;
 import com.uber.rxcentralble.GattManager;
-import com.uber.rxcentralble.Irrelevant;
 import com.uber.rxcentralble.RxCentralLogger;
 import com.uber.rxcentralble.core.operations.Read;
 import com.uber.rxcentralble.core.operations.RegisterNotification;
@@ -80,16 +78,15 @@ public class MainActivity extends AppCompatActivity {
                 .connect(new NameScanMatcher(name),
                         DEFAULT_SCAN_TIMEOUT,
                         DEFAULT_CONNECTION_TIMEOUT)
-                .retryWhen(
-                        errors ->
-                                errors.flatMap(
-                                        error -> {
-                                          /*if (error instanceof ConnectionError) {
-                                            return Observable.just(Irrelevant.INSTANCE);
-                                          }*/
+                .retryWhen(errors ->
+                        errors.flatMap(
+                            error -> {
+                              /*if (error instanceof ConnectionError) {
+                                return Observable.just(Irrelevant.INSTANCE);
+                              }*/
 
-                                          return Observable.error(error);
-                                        }))
+                              return Observable.error(error);
+                            }))
                 .subscribe(
                         gattIO -> {
                           gattManager.setGattIO(gattIO);

--- a/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/MainActivity.java
+++ b/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/MainActivity.java
@@ -9,8 +9,10 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.uber.rxcentralble.ConnectionError;
 import com.uber.rxcentralble.ConnectionManager;
 import com.uber.rxcentralble.GattManager;
+import com.uber.rxcentralble.Irrelevant;
 import com.uber.rxcentralble.RxCentralLogger;
 import com.uber.rxcentralble.core.operations.Read;
 import com.uber.rxcentralble.core.operations.RegisterNotification;
@@ -19,6 +21,7 @@ import com.uber.rxcentralble.core.operations.RequestMtu;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
@@ -77,6 +80,16 @@ public class MainActivity extends AppCompatActivity {
                 .connect(new NameScanMatcher(name),
                         DEFAULT_SCAN_TIMEOUT,
                         DEFAULT_CONNECTION_TIMEOUT)
+                .retryWhen(
+                        errors ->
+                                errors.flatMap(
+                                        error -> {
+                                          /*if (error instanceof ConnectionError) {
+                                            return Observable.just(Irrelevant.INSTANCE);
+                                          }*/
+
+                                          return Observable.error(error);
+                                        }))
                 .subscribe(
                         gattIO -> {
                           gattManager.setGattIO(gattIO);


### PR DESCRIPTION
…cation

The old write chunking logic involved copying the entire byte array into separate chunk arrays and placing into a replay subject.

New chunking logic simply outputs an index of the chunk and a byte buffer, so there is no duplication of data.