### PR TITLE
Now shipping two useful scan matchers

### DIFF
--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreConnectionManager.java
@@ -54,7 +54,7 @@ public class CoreConnectionManager implements ConnectionManager {
   @Nullable
   private ScanMatcher scanMatcher;
   @Nullable
-  private Observable<GattIO> sharedGattIOObservable;
+  protected Observable<GattIO> sharedGattIOObservable;
 
   private int scanTimeoutMs = DEFAULT_SCAN_TIMEOUT;
   private int connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT;
@@ -126,7 +126,10 @@ public class CoreConnectionManager implements ConnectionManager {
                 .doOnNext(connectableGattIO -> stateRelay.accept(State.CONNECTED))
                 .doOnDispose(() -> stateRelay.accept(State.DISCONNECTED))
                 .doOnError(error -> stateRelay.accept(State.DISCONNECTED_WITH_ERROR))
-                .doFinally(() -> this.scanMatcher = null)
+                .doFinally(() -> {
+                  this.sharedGattIOObservable = null;
+                  this.scanMatcher = null;
+                })
                 .map(connectableGattIO -> connectableGattIO)
                 .replay(1)
                 .refCount();

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/matchers/RssiScanMatcher.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/matchers/RssiScanMatcher.java
@@ -1,0 +1,81 @@
+package com.uber.rxcentralble.core.matchers;
+
+import com.uber.rxcentralble.ScanData;
+import com.uber.rxcentralble.ScanMatcher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.ObservableTransformer;
+
+/**
+ * ScanMatcher that matches the closest (gauged by RSSI) peripheral advertising a service UUID.
+ */
+public class RssiScanMatcher implements ScanMatcher {
+
+  private final ServiceScanMatcher serviceScanMatcher;
+  private final Map<String, ScanData> matches = new HashMap<>();
+  private final Object syncRoot = new Object();
+
+  public RssiScanMatcher(UUID serviceUuid, ServiceScanMatcher serviceScanMatcher) {
+    this.serviceScanMatcher = serviceScanMatcher;
+  }
+
+  /**
+   * Take a stream of scan data, match by service uuid, wait 1500ms, then check to see if this is
+   * the closest (gauged by RSSI) discovered peripheral with that service uuid.
+   *
+   * @return transformed stream of matches.
+   */
+  @Override
+  public ObservableTransformer<ScanData, ScanData> match() {
+    return scanDataStream ->
+            scanDataStream
+                    .doOnSubscribe(disposable -> matches.clear())
+                    .compose(serviceScanMatcher.match())
+                    .doOnNext(scanData -> {
+                      synchronized (syncRoot) {
+                        matches.put(scanData.getBluetoothDevice().getAddress(), scanData);
+                      }
+                    })
+                    .delay(1500, TimeUnit.MILLISECONDS)
+                    .filter(match -> {
+                      synchronized (syncRoot) {
+                        for (ScanData other : matches.values()) {
+                          // Skip our self.
+                          if (other.getBluetoothDevice().getAddress().contentEquals(
+                                  match.getBluetoothDevice().getAddress())) {
+                            continue;
+                          }
+
+                          // If the other match is closer then do not match.
+                          // RSSI is measured in dB; negative values, closer to zero indicates
+                          // stronger signal.
+                          if (other.getRssi() > match.getRssi()) {
+                            return false;
+                          }
+                        }
+
+                        // This is our match.
+                        return true;
+                      }
+                    });
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o != null && o instanceof RssiScanMatcher) {
+      RssiScanMatcher other = (RssiScanMatcher) o;
+      return other.serviceScanMatcher.equals(this.serviceScanMatcher);
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return serviceScanMatcher.hashCode();
+  }
+}

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/matchers/ServiceScanMatcher.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/matchers/ServiceScanMatcher.java
@@ -1,0 +1,86 @@
+package com.uber.rxcentralble.core.matchers;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.ParcelUuid;
+
+import com.uber.rxcentralble.ScanData;
+import com.uber.rxcentralble.ScanMatcher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import io.reactivex.ObservableTransformer;
+
+/**
+ * ScanMatcher that matches the first discovered peripheral advertising a service UUID.
+ */
+public class ServiceScanMatcher implements ScanMatcher {
+
+  private final UUID serviceUuid;
+
+  public ServiceScanMatcher(UUID serviceUuid) {
+    this.serviceUuid = serviceUuid;
+  }
+
+  @Override
+  public ObservableTransformer<ScanData, ScanData> match() {
+    return scanData -> scanData.filter(this::matchByUUID);
+  }
+
+  /* This helper function is to match BLE device by service UUID. */
+  private boolean matchByUUID(ScanData scanData) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      List<ParcelUuid> uuids = getParcelUuid(scanData);
+
+      if (uuids.size() > 0) {
+        ParcelUuid serviceParcelUuid = new ParcelUuid(serviceUuid);
+        for (ParcelUuid uuid : uuids) {
+          if (uuid.equals(serviceParcelUuid)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    if (scanData.getParsedAdvertisement() != null
+        && scanData.getParsedAdvertisement().hasService(serviceUuid)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  @TargetApi(21)
+  private List<ParcelUuid> getParcelUuid(ScanData scanData) {
+    List<ParcelUuid> uuids = new ArrayList<>();
+    if (scanData.getScanResult() != null
+            && scanData.getScanResult().getScanRecord() != null
+            && scanData.getScanResult().getScanRecord().getServiceUuids() != null) {
+      uuids.addAll(scanData.getScanResult().getScanRecord().getServiceUuids());
+    }
+
+    if (scanData.getBluetoothDevice() != null && scanData.getBluetoothDevice().getUuids() != null) {
+      uuids.addAll(Arrays.asList(scanData.getBluetoothDevice().getUuids()));
+    }
+
+    return uuids;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ServiceScanMatcher) {
+      ServiceScanMatcher other = (ServiceScanMatcher) o;
+      return other.serviceUuid.equals(this.serviceUuid);
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return serviceUuid.hashCode();
+  }
+}

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/matchers/RssiScanMatcherTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/matchers/RssiScanMatcherTest.java
@@ -1,0 +1,101 @@
+package com.uber.rxcentralble.core.matchers;
+
+import android.bluetooth.BluetoothDevice;
+
+import com.jakewharton.rxrelay2.BehaviorRelay;
+import com.jakewharton.rxrelay2.Relay;
+import com.uber.rxcentralble.ScanData;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.ObservableTransformer;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.plugins.RxJavaPlugins;
+import io.reactivex.schedulers.TestScheduler;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class RssiScanMatcherTest {
+
+  private final TestScheduler testScheduler = new TestScheduler();
+
+  @Mock ScanData scanData1;
+  @Mock ScanData scanData2;
+  @Mock BluetoothDevice bluetoothDevice1;
+  @Mock BluetoothDevice bluetoothDevice2;
+  @Mock ServiceScanMatcher serviceScanMatcher;
+
+  private UUID uuid = UUID.randomUUID();
+  private Relay<ScanData> scanDataRelay = BehaviorRelay.create();
+  private TestObserver<ScanData> scanDataTestObserver;
+  private ObservableTransformer<ScanData, ScanData> serviceMatch;
+
+  private RssiScanMatcher rssiScanMatcher;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    RxJavaPlugins.setComputationSchedulerHandler(schedulerCallable -> testScheduler);
+
+    when(scanData1.getBluetoothDevice()).thenReturn(bluetoothDevice1);
+    when(scanData2.getBluetoothDevice()).thenReturn(bluetoothDevice2);
+
+    when(bluetoothDevice1.getAddress()).thenReturn("bluetoothDevice1");
+    when(bluetoothDevice2.getAddress()).thenReturn("bluetoothDevice2");
+
+    rssiScanMatcher = new RssiScanMatcher(uuid, serviceScanMatcher);
+  }
+
+  @After
+  public void after() {
+    RxJavaPlugins.reset();
+  }
+
+  @Test
+  public void match_none() {
+    ObservableTransformer<ScanData, ScanData> serviceMatch = scanData -> scanData.filter(sd -> false);
+    when(serviceScanMatcher.match()).thenReturn(serviceMatch);
+
+    scanDataTestObserver = scanDataRelay
+            .compose(rssiScanMatcher.match())
+            .test();
+
+    scanDataRelay.accept(scanData1);
+    scanDataRelay.accept(scanData2);
+    scanDataTestObserver.assertEmpty();
+  }
+
+  @Test
+  public void match_closest() {
+    ObservableTransformer<ScanData, ScanData> serviceMatch = scanData -> scanData.filter(sd -> true);
+    when(serviceScanMatcher.match()).thenReturn(serviceMatch);
+
+    scanDataTestObserver = scanDataRelay
+            .compose(rssiScanMatcher.match())
+            .test();
+
+    when(scanData1.getRssi()).thenReturn(-60);
+    when(scanData2.getRssi()).thenReturn(-50);
+
+    scanDataRelay.accept(scanData1);
+
+    testScheduler.advanceTimeBy(500, TimeUnit.MILLISECONDS);
+
+    scanDataRelay.accept(scanData2);
+
+    testScheduler.advanceTimeBy(2500, TimeUnit.MILLISECONDS);
+
+    scanDataTestObserver.assertValue(scanData2);
+  }
+}

--- a/rx-central-ble/src/test/java/com/uber/rxcentralble/core/matchers/ServiceScanMatcherTest.java
+++ b/rx-central-ble/src/test/java/com/uber/rxcentralble/core/matchers/ServiceScanMatcherTest.java
@@ -1,0 +1,94 @@
+package com.uber.rxcentralble.core.matchers;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.le.ScanRecord;
+import android.bluetooth.le.ScanResult;
+import android.os.ParcelUuid;
+
+import com.jakewharton.rxrelay2.BehaviorRelay;
+import com.jakewharton.rxrelay2.Relay;
+import com.uber.rxcentralble.ParsedAdvertisement;
+import com.uber.rxcentralble.ScanData;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import io.reactivex.observers.TestObserver;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class ServiceScanMatcherTest {
+
+  @Mock ScanData scanData;
+  @Mock BluetoothDevice bluetoothDevice;
+  @Mock ScanResult scanResult;
+  @Mock ScanRecord scanRecord;
+  @Mock ParsedAdvertisement parsedAdvertisement;
+
+  private UUID uuid = UUID.randomUUID();
+  private ParcelUuid parcelUuid = new ParcelUuid(uuid);
+  private List<ParcelUuid> uuidList = new ArrayList<>();
+  private ParcelUuid[] uuidArray = new ParcelUuid[1];
+  private Relay<ScanData> scanDataRelay = BehaviorRelay.create();
+  private TestObserver<ScanData> scanDataTestObserver;
+
+  private ServiceScanMatcher serviceScanMatcher;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    when(scanData.getScanResult()).thenReturn(scanResult);
+    when(scanResult.getScanRecord()).thenReturn(scanRecord);
+
+    when(scanData.getBluetoothDevice()).thenReturn(bluetoothDevice);
+    when(scanData.getParsedAdvertisement()).thenReturn(parsedAdvertisement);
+
+    serviceScanMatcher = new ServiceScanMatcher(uuid);
+    scanDataTestObserver = scanDataRelay
+            .compose(serviceScanMatcher.match())
+            .test();
+  }
+
+  @Test
+  public void match_none() {
+    scanDataRelay.accept(scanData);
+    scanDataTestObserver.assertEmpty();
+  }
+
+  @Test
+  public void match_scanResult() {
+    uuidList.add(parcelUuid);
+    when(scanRecord.getServiceUuids()).thenReturn(uuidList);
+
+    scanDataRelay.accept(scanData);
+    scanDataTestObserver.assertValue(scanData);
+  }
+
+  @Test
+  public void match_bluetoothDevice() {
+    uuidArray[0] = parcelUuid;
+    when(bluetoothDevice.getUuids()).thenReturn(uuidArray);
+
+    scanDataRelay.accept(scanData);
+    scanDataTestObserver.assertValue(scanData);
+  }
+
+  @Test
+  public void match_parsedAdvertisement() {
+    when(parsedAdvertisement.hasService(Matchers.eq(uuid))).thenReturn(true);
+
+    scanDataRelay.accept(scanData);
+    scanDataTestObserver.assertValue(scanData);
+  }
+}


### PR DESCRIPTION
ServiceScanMatcher - matches the first discovered peripheral advertising a specified service uuid.
RssiScanMatcher - matches the closes discovered peripheral advertising a specified service uuid.
