### PR TITLE
Bluetooth detector fix for unregister on devices that do not support …

### DIFF
--- a/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/SampleApplication.java
+++ b/rx-central-ble-sample/src/main/java/com/uber/rxcentralble/sample/SampleApplication.java
@@ -1,6 +1,10 @@
 package com.uber.rxcentralble.sample;
 
+import android.annotation.TargetApi;
 import android.app.Application;
+import android.os.Build;
+
+import com.uber.rxcentralble.BluetoothDetector;
 import com.uber.rxcentralble.ConnectionManager;
 import com.uber.rxcentralble.GattManager;
 import com.uber.rxcentralble.Utils;
@@ -26,15 +30,22 @@ public class SampleApplication extends Application {
 
   private ConnectionManager connectionManager;
   private GattManager gattManager;
+  private BluetoothDetector bluetoothDetector;
 
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   @Override
   public void onCreate() {
     super.onCreate();
 
+    bluetoothDetector = new CoreBluetoothDetector(this.getApplicationContext());
     gattManager = new CoreGattManager();
     connectionManager = new CoreConnectionManager(this,
             new CoreBluetoothDetector(this),
             new CoreGattIO.Factory());
+  }
+
+  public BluetoothDetector getBluetoothDetector() {
+    return bluetoothDetector;
   }
 
   public ConnectionManager getConnectionManager() {

--- a/rx-central-ble-sample/src/main/res/layout/activity_main.xml
+++ b/rx-central-ble-sample/src/main/res/layout/activity_main.xml
@@ -52,7 +52,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/batteryButton" />
+        app:layout_constraintTop_toBottomOf="@+id/toggleButtonBleDetect" />
 
     <Button
         android:id="@+id/batteryButton"
@@ -83,5 +83,18 @@
         android:text="GAP"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/nameEditText" />
+
+    <ToggleButton
+        android:id="@+id/toggleButtonBleDetect"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="8dp"
+        android:text="ToggleButton"
+        android:textOff="BLE Detect Off"
+        android:textOn="BLE Detect On"
+        android:visibility="visible"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/gapButton" />
 
 </android.support.constraint.ConstraintLayout>

--- a/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreBluetoothDetector.java
+++ b/rx-central-ble/src/main/java/com/uber/rxcentralble/core/CoreBluetoothDetector.java
@@ -47,7 +47,7 @@ public class CoreBluetoothDetector implements BluetoothDetector {
           @Override
           public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
-            if (action.equals(BluetoothAdapter.ACTION_STATE_CHANGED)) {
+            if (action != null && action.equals(BluetoothAdapter.ACTION_STATE_CHANGED)) {
               int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1);
 
               if (RxCentralLogger.isDebug()) {
@@ -100,7 +100,13 @@ public class CoreBluetoothDetector implements BluetoothDetector {
   }
 
   private void stopDetection() {
-    context.unregisterReceiver(bluetoothStateReceiver);
+    try {
+      context.unregisterReceiver(bluetoothStateReceiver);
+    } catch (IllegalArgumentException e) {
+      if (RxCentralLogger.isError()) {
+        RxCentralLogger.error("stopDetection - Unregister receiver failed!");
+      }
+    }
 
     bluetoothEnabledRelay.accept(Capability.UNSUPPORTED);
   }


### PR DESCRIPTION
…Bluetooth LE

An IllegalArgumentException occurs if you unregister a receiver that was never registered.  This occurs on devices that do not support Bluetooth LE, such as emulators.